### PR TITLE
Correcting import of formatDate

### DIFF
--- a/src/scenes/calendar/calendar.jsx
+++ b/src/scenes/calendar/calendar.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import FullCalendar, { formatDate } from "@fullcalendar/react";
+import FullCalendar from "@fullcalendar/react";
+import { formatDate } from "@fullcalendar/core";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";


### PR DESCRIPTION
I ran into several issues here with the formatDate function.  looking into the moduale shows formatDate is a function in @fullcalendar/core/index.js and not /react